### PR TITLE
core/resource: combine define-static-resource and define-runtime-path

### DIFF
--- a/congame-example-study/example.rkt
+++ b/congame-example-study/example.rkt
@@ -4,20 +4,17 @@
          congame/components/resource
          congame/components/study
          (except-in forms form)
-         koyo/haml
-         racket/runtime-path)
+         koyo/haml)
 
 (provide
  consent-study
  simple-study)
 
 ;; Directory resources:
-(define-runtime-path songs-path "songs")
-(define-static-resource songs songs-path)
+(define-static-resource songs "songs")
 
 ;; File resources:
-(define-runtime-path christmas-song-path (build-path "songs" "christmas.ogg"))
-(define-static-resource christmas-song christmas-song-path)
+(define-static-resource christmas-song (build-path "songs" "christmas.ogg"))
 
 ;; example ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
`define-runtime-path` uses the source module of its macro application
to determine the base directory so the "trick" here is to generate a
macro application whose `syntax-source-module` is that of the calling
module, but refer to identifiers within the macro's own scope so as
not to break hygiene.