### PR TITLE
app: use current-header-handler to log response codes and timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/info.rkt') }}-${{ hashFiles('ci/setup-catalogs.sh') }}
 
     - name: Install Racket
-      uses: Bogdanp/setup-racket@v1.8.1
+      uses: Bogdanp/setup-racket@v1.10
       with:
         architecture: 'x64'
         distribution: 'full'
         variant: 'CS'
-        version: '8.5'
+        version: '8.8'
 
     - name: Install Racket deps
       run: |
@@ -107,12 +107,12 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/info.rkt') }}-${{ hashFiles('ci/setup-catalogs.sh') }}
 
     - name: Install Racket
-      uses: Bogdanp/setup-racket@v1.8.1
+      uses: Bogdanp/setup-racket@v1.10
       with:
         architecture: 'x64'
         distribution: 'full'
         variant: 'CS'
-        version: '8.5'
+        version: '8.8'
 
     - name: Install Racket deps
       run: |

--- a/ci/setup-catalogs.sh
+++ b/ci/setup-catalogs.sh
@@ -6,5 +6,5 @@ echo "Setting up user catalogs..."
 raco pkg config \
      --user \
      --set catalogs \
-     https://download.racket-lang.org/releases/8.5/catalog/ \
-     https://racksnaps.defn.io/snapshots/2022/06/16/catalog/
+     https://download.racket-lang.org/releases/8.8/catalog/ \
+     https://racksnaps.defn.io/snapshots/2023/04/18/catalog/


### PR DESCRIPTION
TODO after we bump the deployed Racket version.