### PR TITLE
DSL zip files

### DIFF
--- a/congame-core/components/dsl.rkt
+++ b/congame-core/components/dsl.rkt
@@ -1,7 +1,14 @@
 #lang racket/base
 
-(require racket/file
-         racket/format)
+(require file/unzip
+         racket/file
+         racket/format
+         racket/lazy-require
+         racket/match
+         racket/port)
+
+(lazy-require
+ [congame-web/components/upload (call-with-uploaded-file)])
 
 (provide
  dsl-require)
@@ -9,6 +16,28 @@
 (define-logger dsl)
 
 (define (dsl-require src id)
+  (match src
+    [`(archive ,path)
+     (call-with-uploaded-file path
+       (lambda (in)
+         (define dir
+           (read-zip-directory in))
+         (define entry-name
+           (for/first ([e (in-list (zip-directory-entries dir))]
+                       #:when (regexp-match? #rx#"/?study.rkt$" e))
+             e))
+         (unless entry-name
+           (error 'dsl-require "no study.rkt found in zip file"))
+         (define data "")
+         (unzip-entry
+          in dir entry-name
+          (lambda (_name _dir? entry-in)
+            (set! data (port->string entry-in))))
+         (dsl-require* data id)))]
+    [_
+     (dsl-require* src id)]))
+
+(define (dsl-require* src id)
   (log-dsl-debug "dsl-require: ~a" (~.s #:max-width 1024 src))
   (unless (regexp-match? #rx"^#lang conscript *\n" src)
     (error 'dsl-require "only #lang conscript is supported"))

--- a/congame-core/components/resource.rkt
+++ b/congame-core/components/resource.rkt
@@ -2,7 +2,7 @@
 
 (require (for-syntax racket/base
                      racket/syntax
-                     syntax/parse)
+                     syntax/parse/pre)
          file/md5
          racket/runtime-path)
 

--- a/congame-core/components/study.rkt
+++ b/congame-core/components/study.rkt
@@ -1187,6 +1187,7 @@ QUERY
    [slug string/f #:contract non-empty-string?]
    [racket-id symbol/f]
    [(dsl-source "") string/f #:contract string?]
+   [(dsl-archive-path sql-null) string/f #:contract string? #:nullable]
    [(created-at (now/moment)) datetime-tz/f]))
 
 (define-schema study-instance
@@ -1512,9 +1513,13 @@ QUERY
       (lambda (id)
         (error 'lookup-registered-study "No such registered study: ~s~n. Did you install the necessary congame-studies?" id)))]
     [(dsl)
-     (dsl-require
-      (study-meta-dsl-source meta)
-      (study-meta-racket-id meta))]))
+     (if (sql-null? (study-meta-dsl-archive-path meta))
+         (dsl-require
+          (study-meta-dsl-source meta)
+          (study-meta-racket-id meta))
+         (dsl-require
+          `(archive ,(study-meta-dsl-archive-path meta))
+          (study-meta-racket-id meta)))]))
 
 (define/contract (lookup-study-meta db study-id)
   (-> database? id/c (or/c #f study-meta?))

--- a/congame-example-study/zip-study-example/img/code-screenshot.png
+++ b/congame-example-study/zip-study-example/img/code-screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8eddef6d016f6de909c4081323cdced38d238fcfcf205653a59e9495e4cb44
+size 60980

--- a/congame-example-study/zip-study-example/study.rkt
+++ b/congame-example-study/zip-study-example/study.rkt
@@ -1,0 +1,18 @@
+#lang conscript
+
+(provide
+ image-example)
+
+(define-static-resource images "img")
+
+(defstep (show-image)
+  @html{
+    @h1{A Page with an Image}
+
+    @img[
+      #:alt "Screenshot of Code"
+      #:src (resource-uri images "code-screenshot.png")
+    ]})
+
+(defstudy image-example
+  [show-image --> show-image])

--- a/congame-web-migrations/20240308-add-study-dsl-archive-path.sql
+++ b/congame-web-migrations/20240308-add-study-dsl-archive-path.sql
@@ -1,0 +1,14 @@
+#lang north
+
+-- @revision: e2578f4ce14178e995096cca7f636662
+-- @parent: 147355c994f5361ae6d7df3ebbe741e3
+-- @description: Adds the dsl_archive_path column to studies.
+-- @up {
+ALTER TABLE studies
+  ADD COLUMN dsl_archive_path TEXT DEFAULT NULL;
+-- }
+
+-- @down {
+ALTER TABLE studies
+  DROP COLUMN dsl_archive_path;
+-- }

--- a/congame-web/components/app.rkt
+++ b/congame-web/components/app.rkt
@@ -217,7 +217,10 @@
       serve-resource-page]
 
      [("resource" (string-arg) (string-arg))
-      serve-resource-page]))
+      serve-resource-page]
+
+     [("dsl-resource" (integer-arg) (string-arg) ...)
+      (serve-dsl-resource-page db)]))
 
   ;; Requests go up (starting from the last wrapper) and respones go down!
   (define wrap-sentry

--- a/congame-web/components/upload.rkt
+++ b/congame-web/components/upload.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (require koyo/random
-         racket/contract
+         racket/contract/base
+         racket/contract/region
          racket/format
          racket/port
          web-server/http)

--- a/congame-web/pages/admin.rkt
+++ b/congame-web/pages/admin.rkt
@@ -428,9 +428,17 @@
        (match (form-run edit-study-dsl-form req #:defaults defaults)
          [(list 'passed (list dsl-id dsl-source) _)
           (with-database-connection [conn db]
-            (update-one! conn (~> meta
-                                  (set-study-meta-racket-id _ dsl-id)
-                                  (set-study-meta-dsl-source _ dsl-source))))
+            (~> meta
+                (set-study-meta-racket-id dsl-id)
+                (set-study-meta-dsl-source
+                 (match dsl-source
+                   [`(source ,source) source]
+                   [_ ""]))
+                (set-study-meta-dsl-archive-path
+                 (match dsl-source
+                   [`(archive ,path) path]
+                   [_ sql-null]))
+                (update-one! conn _)))
           (redirect-to (reverse-uri 'admin:view-study-page study-id))]
 
          [(list _ _ rw)

--- a/congame-web/pages/resource.rkt
+++ b/congame-web/pages/resource.rkt
@@ -1,13 +1,19 @@
 #lang racket/base
 
-(require congame/components/resource
+(require congame-web/components/upload
+         congame/components/resource
+         congame/components/study
+         db
+         file/unzip
          koyo/mime
+         racket/path
          racket/port
          web-server/dispatchers/dispatch
          web-server/http)
 
 (provide
- serve-resource-page)
+ serve-resource-page
+ serve-dsl-resource-page)
 
 (define (serve-resource-page _req id [subresource #f])
   (define r (get-resource id))
@@ -26,3 +32,36 @@
      (call-with-input-file full-path
        (lambda (in)
          (copy-port in out))))))
+
+(define ((serve-dsl-resource-page db) _req instance-id path-elements)
+  (define instance (lookup-study-instance db instance-id))
+  (unless instance (next-dispatcher))
+  (define study (lookup-study-meta db (study-instance-study-id instance)))
+  (define path (and study (study-meta-dsl-archive-path study)))
+  (unless (and path (not (sql-null? path)))
+    (next-dispatcher))
+  (call-with-uploaded-file
+   path
+   (lambda (in)
+     (define dir
+       (read-zip-directory in))
+     (define study-path
+       (for/first ([e (in-list (zip-directory-entries dir))]
+                   #:when (regexp-match? #rx#"/?study.rkt$" e))
+         (bytes->path e)))
+     (unless study-path
+       (next-dispatcher))
+     (define study-dir-path
+       (path-only study-path))
+     (define entry-path
+       (apply build-path study-dir-path path-elements))
+     (define data #"")
+     (unzip-entry
+      in dir (path->bytes entry-path)
+      (lambda (_name _dir? entry-in)
+        (set! data (port->bytes entry-in))))
+     (response/output
+      #:mime-type (path->mime-type entry-path)
+      #:headers (list (header #"content-length" (string->bytes/utf-8 (number->string (bytes-length data)))))
+      (lambda (out)
+        (write-bytes data out))))))

--- a/conscript/base.rkt
+++ b/conscript/base.rkt
@@ -18,6 +18,7 @@
          "form.rkt"
          "html.rkt"
          "markdown.rkt"
+         "resource.rkt"
          "var.rkt")
 
 (lazy-require
@@ -81,6 +82,7 @@
  (all-from-out "form.rkt")
  (all-from-out "html.rkt")
  (all-from-out "markdown.rkt")
+ (all-from-out "resource.rkt")
  defstep
  defstep/study
  defstudy

--- a/conscript/resource.rkt
+++ b/conscript/resource.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         congame/components/study
+         koyo/url
+         racket/format)
+
+(provide
+ define-static-resource
+ resource-uri)
+
+(struct resource (path))
+
+(define-syntax (define-static-resource stx)
+  (syntax-parse stx
+    [(_ name:id path:string)
+     #'(define name (resource path))]))
+
+(define (resource-uri r)
+  (make-application-url
+   "dsl-resource"
+   (~a (current-study-instance-id))
+   (resource-path r)))

--- a/conscript/resource.rkt
+++ b/conscript/resource.rkt
@@ -17,8 +17,11 @@
     [(_ name:id path:string)
      #'(define name (resource path))]))
 
-(define (resource-uri r)
-  (make-application-url
-   "dsl-resource"
-   (~a (current-study-instance-id))
-   (resource-path r)))
+(define (resource-uri r [subr #f])
+  (apply
+   make-application-url
+   (append
+    `("dsl-resource"
+      ,(~a (current-study-instance-id))
+      ,(resource-path r))
+    (if subr (list subr) '()))))


### PR DESCRIPTION
Example: [study.zip](https://github.com/MarcKaufmann/congame/files/14538739/study.zip)

Adds support for uploading DSL studies in a zip file and declaring static resources within those studies. Each zip file must contain a `study.rkt` file. `define-static-resource` paths are relative to that file within the zip file. For example, if the zip file contains a single directory, `foo`, at its root, and that directory contains the `study.rkt` file and the module declares a static resource as `(define-static-resource hello.txt "hello.txt")`, then `(resource-uri hello.txt)` will effectively resolve to `foo/hello.txt`.