### PR TITLE
Add PD study tutorial and module reference content

### DIFF
--- a/congame-doc/conscript-tutorial.scrbl
+++ b/congame-doc/conscript-tutorial.scrbl
@@ -1,7 +1,8 @@
 #lang scribble/manual
 
 @(require (for-label conscript/base
-                     racket/contract)
+                     racket/contract
+                     racket/match)
           "doc-util.rkt")
 
 @title{Conscript tutorial: simple studies}
@@ -14,7 +15,7 @@ We're going to make a study that pits participants against each other in this sc
 
 @codeblock[#:keep-lang-line? #f]{
   #lang conscript
-  (defvar/instance choices dilemma-choices)
+  (defvar/instance all-choice-groups dilemma-choices)
   (defvar outcome)
 }
 
@@ -80,16 +81,16 @@ matchmaker function will skip the user to the next step in the study.
 
   (define (make-choice! choice)
     (with-study-transaction
-      (set! choices ((&my-choice) (if-undefined choices (hash)) choice))))
+      (set! all-choice-groups ((&my-choice) (if-undefined all-choice-groups (hash)) choice))))
 }|
 
-The @racket[choices] is a hash table whose keys are all the groups in the study instance. If we get
-the value for @racket[get-current-group], we get another hash table whose keys are the participants
-in that group, and whose values are their individual choices.
+The @racket[all-choice-groups] is a hash table whose keys are all the groups in the study instance.
+If we get that table’s value for @racket[get-current-group], we get another hash table whose keys
+are the participants in that group, and whose values are their individual choices.
 
-This is all very complicated but it’s basically saying “take the whole choices hash table and update
-just the value for the current participant in the current group.” @mark{Lenses are cool, read about
-them.}
+This code is all very complicated but it’s basically saying “take the whole @tt{all-choice-groups}
+hash table and update just the value for the current participant in the current group.” @mark{Lenses
+are cool, read about them.}
 
 @codeblock[#:keep-lang-line? #f]|{
   #lang conscript
@@ -114,7 +115,7 @@ function we defined above.
 @codeblock[#:keep-lang-line? #f]|{
   #lang conscript
   (defstep (wait)
-    (if (= (hash-count (hash-ref choices (get-current-group))) 1)
+    (if (= (hash-count (hash-ref all-choice-groups (get-current-group))) 1)
         @md{# Please Wait
 
             Please wait for the other participant to make their choice...
@@ -130,11 +131,17 @@ it finds 2 choices, it automatically skips to the next step.
 
 @codeblock[#:keep-lang-line? #f]|{
   #lang conscript
+  ; Helper function
+  (define (group->choices group)
+    (match group
+      [(hash (current-participant-id) my-choice
+             #:rest (app hash-values (list their-choice)))
+       (values my-choice their-choice)]))
+
   (defstep (display-result)
-      (match-define 
-        (hash (current-participant-id) my-choice 
-              #:rest (app hash-values (list their-choice)))
-        (hash-ref choices (get-current-group)))
+    (define my-group (hash-ref all-choice-groups (get-current-group)))
+    (define-values (my-choice their-choice) 
+      (group->choices my-group))
     (set! outcome
           (match* (my-choice their-choice)
             [('cooperate 'cooperate) 1]
@@ -147,13 +154,13 @@ it finds 2 choices, it automatically skips to the next step.
         You get @~a[outcome] years of prison.})
 }|
 
-Ok here's the thing. The current “group” is a hash of participant IDs to choices. We know what the
-current participant's ID is, but we don't know the ID of the rando we got paired with (and we don’t
-care). So the @racket[match-define] expression is a way to say “find my choice in the current group
-and put it here, and whatever the other person’s response was, put it over there.”
+The current “group” is a hash of participant IDs to choices. We know what the current participant's
+ID is, but we don't know the ID of the rando we got paired with (and we don’t care). So the
+@racket[group-choices] helper function is a way to say “find my choice in the current group and put
+it here, and whatever the other person’s response was, put it over there.”
 
 Then we set @racket[outcome] to the result of the paired choices. This records it in the database.
-We also display it to the user (~a converts the number to a string).
+We also display it to the user (@racket[~a] converts the number to a string).
 
 @codeblock[#:keep-lang-line? #f]|{
   #lang conscript
@@ -162,5 +169,12 @@ We also display it to the user (~a converts the number to a string).
     [display-result --> display-result])
 }|
 
-Gotta define the whole study.
+@tktk{Define the whole study.}
+
+@;===============================================
+
+@section{Testing the Prisoner’s Dilemma}
+
+@tktk{Upload and test; tricks for logging in anonymously in another tab to simulate a second
+participant}
 

--- a/congame-doc/doc-util.rkt
+++ b/congame-doc/doc-util.rkt
@@ -24,9 +24,9 @@
 
 ;; Mark filler content as placeholders for the real thing to be added later
 (define (tktk . elems)
-  (element (style "tktk" (list (css-style-addition congame-css)
-                               (alt-tag "span")))
-           `(,(icon "Content to be added later" "⏳") ,@elems)))
+  (compound-paragraph
+    (style "tktk" (list (css-style-addition congame-css) (alt-tag "div")))
+    (decode-flow (cons (icon "Content to be added later" "⏳") elems))))
 
 (define (icon tooltip str)
   (element (style "margin-icon" (list (attributes `([title ,@tooltip]))
@@ -49,6 +49,9 @@
 ;; Simulate a bash-style comment
 (define (rem . args)
   (apply racketcommentfont (cons "# " args)))
+
+(define (html-tag tag-name-str)
+  (racketvalfont (format "<~a>" tag-name-str)))
 
 ;; Style text as a keyboard key or a button
 (define (kbd . elems)

--- a/congame-doc/doc-util.rkt
+++ b/congame-doc/doc-util.rkt
@@ -86,3 +86,16 @@
            (centered
             (image-element (style "figure" (list (css-style-addition congame-css)))
                            '() name-id '() 0.4))))]))
+
+(define-syntax (browser-screenshot stx)
+  (syntax-case stx ()
+    [(_ name-path-str xs ...)
+     (with-syntax ([name-id (datum->syntax stx (string->symbol (syntax-e #'name-path-str)))])
+       #'(begin
+           (define-runtime-path name-id (quote name-path-str))
+           (paragraph
+             (style "browser" (list (css-style-addition congame-css)
+                                    (alt-tag "div")
+                                    (tex-addition congame-tex)))
+             (image-element plain '() name-id '() 0.4))))]))
+

--- a/congame-doc/introduction.scrbl
+++ b/congame-doc/introduction.scrbl
@@ -143,7 +143,7 @@ Click on the @onscreen{New Instance} button. For now, just fill in a value like
 @racketvalfont{Instance 1} in the @italic{Name} field, and leave the rest of the fields at their
 default values:
 
-@screenshot["intro-new-instance.png"]
+@browser-screenshot["intro-new-instance.png"]
 
 Click @kbd{Create} to create an instance of the study.
 
@@ -378,7 +378,7 @@ expression is present in the file.}
 
 If all goes well, you’ll be taken to a page titled @onscreen{Instances of simple-survey}:
 
-@screenshot{intro-empty-instancelist.png}
+@browser-screenshot{intro-empty-instancelist.png}
 
 As before, click on @onscreen{New Instance} and enter a name for the survey instance --- say,
 @racketvalfont{Age Instance 1}. 
@@ -472,12 +472,12 @@ Once you’re done with the study, navigate back to the dashboard. Then click on
 All the way at the bottom, you’ll see a section titled @bold{Participants} — and you’ll be
 the first one:
 
-@screenshot["intro-participant.png"]
+@browser-screenshot["intro-participant.png"]
 
 The number under the @emph{Participant ID} column is a link — go ahead and click on it. You’ll see
 a detailed listing of your responses to the study:
 
-@screenshot["intro-participant-responses.png"]
+@browser-screenshot["intro-participant-responses.png"]
 
 @;===============================================
 

--- a/congame-doc/scrbl-aux.css
+++ b/congame-doc/scrbl-aux.css
@@ -81,16 +81,15 @@ mark {
     font-style: italic;
 }
 
-.tktk:before {
+.tktk .SIntrapara:before {
     content: "[";
 }
 
-.tktk:after {
+.tktk .SIntrapara:after {
     content: "]";
 }
 
 abbr.margin-icon {
-    border-bottom: dotted orange 1px;
     padding: 2px;
     float: left;
     font-style: normal;

--- a/congame-doc/scrbl-aux.css
+++ b/congame-doc/scrbl-aux.css
@@ -10,12 +10,13 @@
 }
 
 .browser {
+    font-family: system-ui, sans-serif;
     margin-bottom: 1em;
     padding: 0 0.5rem;
-    width: 88%;
-    background: white;
+    background: #f5f7fa;
     border: solid silver 1px;
     border-radius: 8px;
+    overflow-x: auto;
 }
 
 .browser:before {
@@ -27,6 +28,11 @@
     margin-left: -0.5rem;
     padding: 0.35rem 0 0.35rem 0.5rem;
     margin-bottom: 0.5rem;
+}
+
+.browser>img {
+    margin-top: -0.5rem;
+    margin-left: -0.5rem
 }
 
 .terminal .SIntrapara {
@@ -62,6 +68,7 @@ kbd {
     width: 7rem;
     height: 1.1em;
     vertical-align: middle;
+    background: #fff;
 }
 
 mark {


### PR DESCRIPTION
The writing here is terse (some might say rude) and experimental. I've done the work to understand exactly how the PD study works under the hood, so I can eventually explain it well, and have written this early draft version according to a simple outline.

Still pondering:

* How much to explain supporting Racket concepts: explain them directly within the tutorial? (for example, lambdas, hash tables, `match-define`, etc.). 
* Whether to add an intermediate tutorial before the PD (we discussed this before, still think it would be a good idea, but we could also bite off everything in one go with PD)

I’ve tried to make some simplifications to the PD study code itself. 