### PR TITLE
Add tool for checking doc coverage

### DIFF
--- a/congame-doc/doc-check/doc-check-lib.rkt
+++ b/congame-doc/doc-check/doc-check-lib.rkt
@@ -1,0 +1,201 @@
+#lang debug racket/base
+
+(require racket/list
+         racket/match
+         racket/string
+         racket/symbol
+         threading)
+
+(provide (all-defined-out))
+
+;;================================================
+;; Binding info
+
+(struct binding (id module type) #:transparent)
+(struct test (module count missing-bindings) #:transparent)
+
+;;================================================
+;; Parameters
+
+(define modules-to-check (make-parameter '()))
+(define ignored-bindings (make-parameter '()))  ; Discard bindings from these modules
+
+;;================================================
+;; Get bindings
+
+;; "module.rkt" 'conscript/base -> 'conscript/module
+(define (->modpath v in-mod)
+  (cond
+    [(not (string? v)) v]
+    [else
+     (define modbase
+       (~> (symbol->immutable-string in-mod)
+           (string-split "/")
+           car))
+     (~> (path-replace-extension v #"")
+         (format "~a/~a" modbase _)
+         string->symbol)]))
+
+;; Returns a list of bindings containing the original identifier and module name, as well as
+;; type 'proc or 'form
+(define (get-bindings mod #:type t)
+  (dynamic-require mod #f)
+  (define-values (vars forms) (module->exports mod))
+  (define lst (if (eq? t 'proc) vars forms))
+  (cond
+    [(null? lst) lst]
+    [else
+     (for/list ([export (in-list (cdar lst))]) ; cdar = only use phase 0
+       (match export
+         [(list id (? null?))
+          (binding id mod t)]
+         [(list id (list (list (? module-path-index?) _ orig-id _) (? module-path-index? orig-mp-idx)))
+          (define-values (orig-mod _base) (module-path-index-split orig-mp-idx))
+          (binding orig-id orig-mod t)]
+         [(list id (list (list (? module-path-index? mp-idx) _ orig-id _)))
+          (define-values (orig-mod _base) (module-path-index-split mp-idx))
+          (binding orig-id orig-mod t)]
+         [(list id (list (? module-path-index? mp-idx)))
+          (define-values (orig-mod _base) (module-path-index-split mp-idx))
+          (binding id (->modpath orig-mod mod) t)]))]))
+
+(define (get-all-bindings mod)
+  (append (get-bindings mod #:type 'proc)
+          (get-bindings mod #:type 'form)))
+
+(define (ignore-binding? b)
+  (match-define (binding id mod _) b)
+  (or
+   (match mod
+     [(? symbol? m)
+      (~> (symbol->immutable-string m)
+          (string-prefix? _ "racket/"))]
+     [_ #f])
+   (for/or ([ignore-pat (in-list (ignored-bindings))])
+     (match ignore-pat
+       [(? symbol? ignore-mod)
+        (eq? mod ignore-mod)]
+       [(list ignore-mod ids-to-ignore ...)
+        (and (eq? mod ignore-mod)
+             (member id ids-to-ignore))]))))
+
+(define (binding-in-mod? b m)
+  (eq? (binding-module b) m))
+
+(define (all-bindings/filter)
+  (remove-duplicates
+   (flatten
+    (for/list ([mod (in-list (modules-to-check))])
+      (filter-not ignore-binding? (get-all-bindings mod))))))
+
+;;================================================
+;; Modules
+
+(define (bindings-list-mod<? lst-a lst-b)
+  (define a (binding-module (car lst-a)))
+  (define b (binding-module (car lst-b)))
+  (cond
+    [(andmap symbol? (list a b))
+     (symbol<? a b)]
+    [(list? a) #f]
+    [else #t]))
+
+(define (group-by-module bindings)
+  (sort (group-by binding-module bindings) bindings-list-mod<?))
+
+;;================================================
+;; Checking Scribble docs
+
+(require racket/format
+         racket/promise
+         scribble/xref
+         setup/xref)
+
+(define collections-xrefs (delay (load-collections-xref)))
+
+;; binding? -> boolean?
+(define (documented? b)
+  (and (xref-binding->definition-tag (force collections-xrefs)
+                                     (list (binding-module b) (binding-id b)) #f) #t))
+
+(define (scribble-module modname)
+  (~a "@;================================================\n\n"
+      "@defmodule[" modname "]\n\n"))
+
+(define (stub-scribble-def bdg)
+  (match-define (binding id _mod type) bdg)
+  (case type
+    [(proc)
+     (~a "@defproc[(" id " [arg any/c]) any/c]{\n\n"
+         id " proc\n\n"
+         "}\n\n")]
+    [(form)
+     (~a "@defform[(" id "arg)\n"
+         "         #:contracts ([arg any/c])]{\n\n"
+         id " form\n\n"
+         "}\n\n")]))
+
+
+;;================================================
+;; Fancy console output
+
+(define in-term?
+  (delay (~> (find-system-path 'exec-file)
+             path->string
+             string-downcase
+             (regexp-match? #rx"gracket" _)
+             not)))
+
+(define (term-bytes . b)
+  (when (force in-term?) (apply write-bytes b)))
+
+;; From https://github.com/lexi-lambda/racket-commonmark/blob/master/commonmark-test/tests/commonmark/spec.rkt
+
+(define color:bold #"\e[1m")
+(define color:red #"\e[31m")
+(define color:green #"\e[32m")
+(define color:yellow #"\e[33m")
+(define color:gray #"\e[90m")
+(define color:reset #"\e(B\e[m")
+
+(define section-title-width (make-parameter 10))
+(define totals-width (make-parameter 10))
+
+(define (write-chars c len)
+  (for ([i (in-range len)])
+    (write-char c)))
+
+(define (write-separator)
+  (write-chars #\─ (+ (section-title-width) (* (totals-width) 2) 58))
+  (newline))
+
+(define (write-header str)
+  (newline)
+  (term-bytes color:bold)
+  (write-string str)
+  (term-bytes color:reset)
+  (newline)
+  (write-separator))
+
+(define (write-bar-line label successes total)
+  (write-string (~a label #:width (section-title-width) #:align 'right))
+  (write-string " ")
+
+  (define score (/ successes total))
+  (define score-color (cond
+                        [(= score 1) color:green]
+                        [(>= score 7/10) color:yellow]
+                        [else color:red]))
+
+  (term-bytes score-color)
+  (define filled-chars (round (* score 50)))
+  (write-chars #\█ filled-chars)
+  (write-chars #\░ (- 50 filled-chars))
+  (write-string " ")
+  (write-string (~r (* score 100) #:precision 0 #:min-width 3))
+  (write-string "%")
+
+  (term-bytes color:gray)
+  (write-string (~a " " (~r successes #:min-width (totals-width)) "/" total))
+  (term-bytes color:reset)
+  (newline))

--- a/congame-doc/doc-check/main.rkt
+++ b/congame-doc/doc-check/main.rkt
@@ -1,0 +1,105 @@
+#lang racket/base
+
+(require racket/cmdline
+         racket/format
+         racket/match
+         threading
+         "doc-check-lib.rkt")
+
+;; Useful tool for checking documentation coverage.
+;; racket -t main.rkt        → list bindings missing docs, and summary bar graphs
+;; racket -t main.rkt -- -s  → print out Scribble stubs (defform/defproc) for bindings missing docs
+
+;; All bindings exported from these modules will be checked to see if they have Scribble
+;; documentation. If a binding is being reprovided from another module, its source will be
+;; given as the module where it was originally defined.
+(modules-to-check
+ '(conscript/base
+   conscript/form
+   conscript/html
+   conscript/markdown
+   conscript/matchmaking
+   conscript/resource
+   conscript/tasks
+   conscript/tool))
+
+;; Some bindings only exist to provide better syntax errors when a form is used
+;; outside its proper context. Others are defined in private-ish modules and
+;; reprovided by other modules. We can ignore these to prevent these from counting
+;; against our coverage score.
+;;
+;; Each element in the list is either: a module path (= ignore all bindings in that module)
+;;                                     list of module path and ids (= ignore just those ids)
+(ignored-bindings
+ '(conscript/html-element
+   (congame/components/transition-graph --> goto)))
+
+;; Any bindings coming from racket/*, as well as those in the “ignore” list above,
+;; are filtered out.
+(define all-bindings (all-bindings/filter))
+
+(define (check-module-docs)
+  (for/list ([bindings (in-list (group-by-module all-bindings))])
+    (define mod (binding-module (car bindings)))
+    (define bindings-not-in-docs
+      (for/list ([b (in-list bindings)]
+                 #:when (not (documented? b)))
+        b))
+    (test mod (length bindings) bindings-not-in-docs)))
+
+;; for each module: show missing bindings and progress bar summary
+(define (list-missing+summary)
+  (define test-results (check-module-docs))
+  (for ([section (in-list test-results)])
+    (match-define (test mod total missing) section)
+    (define miss-count (length missing))
+    (unless (zero? miss-count)
+      (define miss-score (/ miss-count total))
+      (define score-color (cond
+                            [(<= miss-score 3/10) color:yellow]
+                            [else color:red]))
+      (term-bytes score-color)
+      (displayln (format "~a  [missing ~a of ~a]:" mod (length missing) total))
+      (term-bytes color:reset)
+      (for ([b (in-list missing)])
+        (displayln (format "  ~a" (binding-id b))))))
+
+  (section-title-width
+   (~> (for/list ([b (in-list all-bindings)])
+         (string-length (~a (binding-module b))))
+       (apply max _)))
+  (totals-width (string-length (~a (length all-bindings))))
+  (write-header "Congame documentation coverage")
+
+  (define successes 0)
+  (for ([section (in-list test-results)])
+    (match-define (test mod total missing) section)
+    (define success-count (- total (length missing)))
+    (set! successes (+ successes success-count))
+    (write-bar-line mod success-count total))
+
+  (write-separator)
+  (write-bar-line "Total" successes (length all-bindings)))
+
+;; Print out Scribble stub content for bindings missing from the docs.
+(define (scribble-stub-missing)
+  (define test-results (check-module-docs))
+  (for ([section (in-list test-results)])
+    (match-define (test mod total missing) section)
+    (unless (null? missing)
+      (term-bytes color:red color:bold)
+      (write-string (scribble-module mod))
+      (term-bytes color:reset color:yellow)
+      (for ([b (in-list missing)])
+        (write-string (stub-scribble-def b)))))
+  (term-bytes color:reset))
+  
+(module+ main
+  (define proc (make-parameter list-missing+summary))
+  (command-line
+   #:program "doc check"
+   #:once-any
+   [("-s" "--stub-scribble") "Produce Scribble stubs for bindings without documentation"
+                             (proc scribble-stub-missing)])
+  ((proc)))
+


### PR DESCRIPTION
I created a quick tool for checking the level of documentation coverage for conscript/congame modules. It will save me a lot of time in completing the reference correctly, particularly since many functions are reprovided by other modules. Also, since Congame is still under active development and therefore a bit of a moving target, this will be useful for quickly finding any new bindings that may need documentation. 

The tool has three uses:
 
1. Listing all modules/bindings that don't yet have documentation
2. Providing a bar graph/score summary, to measure progress towards complete coverage
3. Producing stub Scribble `defform`/`defproc` content to start documentation for bindings that need it (the tool knows which one to use)

I’m making this PR to give the option of including the tool in the repo. If you feel this kind of thing is “extra”/doesn't really belong in your repo, feel free to close without merging. If you do chose to merge, however, it may give you a useful read on which modules are and aren't being covered in the docs.

Below is a copy of the program's current output. Some of the “missing” bindings may be due to the Scribble docs including the binding under a `defmodule` other than the one where the binding is originally defined, rather than being actually missing. 

```
❯ racket -t main.rkt
congame/components/bot  [missing 1 of 1]:
  current-user-bot?
congame/components/for-study  [missing 1 of 1]:
  for/study
congame/components/formular  [missing 21 of 21]:
  formular-autofill
  input-list
  input-number
  input-range
  map-result
  map-validator
  checkbox
  input-date
  input-file
  input-text
  input-time
  make-checkboxes
  make-radios
  make-radios-with-other
  make-sliders
  map-result*
  select/inline
  textarea
  ~all-errors
  ~error
  ~errors
congame/components/struct  [missing 2 of 2]:
  congame:step?
  congame:study?
congame/components/study  [missing 18 of 22]:
  call-with-study-transaction
  current-participant-id
  current-participant-identity-user?
  current-participant-owner?
  get-current-group-name
  undefined
  undefined?
  defvar
  defvar*
  defvar*/instance
  defvar/instance
  get/linked/instance
  if-undefined
  map-step
  map-study
  put-current-group-name
  with-namespace
  with-study-transaction
conscript/base  [missing 10 of 16]:
  put/identity
  defbox
  log-conscript-debug
  log-conscript-error
  log-conscript-fatal
  log-conscript-info
  log-conscript-warning
  require
  ~current-view-uri
  ~url
conscript/form  [missing 27 of 27]:
  bot:autofill
  input-list
  input-number
  input-range
  map-result
  map-validator
  radios
  select
  submit-button
  submit-button/label
  binding
  checkbox
  form
  input-date
  input-file
  input-text
  input-time
  make-checkboxes
  make-radios
  make-radios-with-other
  make-sliders
  map-result*
  select/inline
  textarea
  ~all-errors
  ~error
  ~errors
conscript/matchmaking  [missing 3 of 5]:
  get-ready-groups
  reset-current-group
  get-pending-groups
conscript/resource  [missing 2 of 2]:
  resource-uri
  define-static-resource
conscript/tasks  [missing 3 of 3]:
  decoding-task
  do-tasks
  answer-correct?
conscript/tool  [missing 1 of 1]:
  get-info
(submod congame/components/bot actions)  [missing 1 of 14]:
  find-attribute
(submod congame/components/formular tools)  [missing 2 of 2]:
  submit-button
  submit-button/label
```

![CleanShot 2025-02-06 at 17 08 47@2x](https://github.com/user-attachments/assets/3597d4af-3975-46d6-a742-469cda27c57a)
