### PR TITLE
Update cookbook and reference

### DIFF
--- a/congame-doc/congame-reference.scrbl
+++ b/congame-doc/congame-reference.scrbl
@@ -150,7 +150,7 @@ scope} --- that is, the stored value is shared by all participants in the study 
   @defthing[#:kind "canary" next next?]
   @defproc[(next? [v any/c]) boolean?]
 )]{
-  A special value that can be used as transition results to cause a
+  A special value that can be used as a transition result to cause a
   study to transition to the next step, whatever step that may be. 
 
   The predicate @racket[next?] returns @racket[#t] if @racket[_v] is
@@ -162,7 +162,7 @@ scope} --- that is, the stored value is shared by all participants in the study 
   @defthing[#:kind "canary" done done?]
   @defproc[(done? [v any/c]) boolean?]
 )]{  
-  A special value that can be used as transition results to cause a
+  A special value that can be used as a transition result to cause a
   transition to the end of the study. 
 
   The predicate @racket[done?] returns @racket[#t] if @racket[_v] is

--- a/congame-doc/congame-reference.scrbl
+++ b/congame-doc/congame-reference.scrbl
@@ -12,6 +12,7 @@
                      congame/components/formular
                      congame/components/study
                      congame/components/transition-graph
+                     (except-in conscript/base require button form select radios)
                      koyo/haml
                      (only-in xml xexpr?)))
 
@@ -465,18 +466,16 @@ is used as the button’s label.
 
 @defmodule[congame/components/transition-graph]
 
-@defform[#:literals (unquote lambda --> goto)
+@defform[#:literals (unquote lambda --> goto done fail)
          (transition-graph transition-clause ...+)
          #:grammar
-         [(transition-clause (code:line [id transition-entry ...+]))
+         [(transition-clause (code:line [id transition-entry ...+ maybe-lambda]))
 
-          (transition-entry (code:line --> transition-target))
+          (transition-entry (code:line --> id))
 
-          (transition-target (code:line id)
-                             (code:line (unquote transition-lambda)))
-
-          (transition-lambda (code:line (lambda () transition-expr ...+))
-                             (code:line (lambda name:id () transition-expr ...+)))
+          (maybe-lambda (code:line)
+                        (code:line (lambda () transition-expr ...+))
+                        (code:line (lambda name:id () transition-expr ...+)))
 
           (transition-expr (code:line (done))
                            (code:line (fail expr))
@@ -493,7 +492,7 @@ is used as the button’s label.
     #:transitions
     (transition-graph
       [a --> b --> ,(lambda ()
-                      (if succes-step-b?
+                      (if success-step-b?
                         (goto bad-ending)
                         (goto good-ending)))]
       [fail-ending --> fail-ending]
@@ -506,6 +505,7 @@ is used as the button’s label.
 }
 
 @deftogether[(@defidform[-->]
+              @defform[(fail expr)]
               @defform[(goto step-id)])]{
 
 Forms used in @racket[transition-graph]s to define transitions between study steps. Use of these

--- a/congame-doc/congame-reference.scrbl
+++ b/congame-doc/congame-reference.scrbl
@@ -147,12 +147,27 @@ scope} --- that is, the stored value is shared by all participants in the study 
 }
 
 @deftogether[(
-  @defthing[#:kind "canary" next any/c]
-  @defthing[#:kind "canary" done any/c]
+  @defthing[#:kind "canary" next next?]
+  @defproc[(next? [v any/c]) boolean?]
 )]{
-  Special values that can be used as transition results to cause a
-  study to transition to the next step or to the end of the study,
-  respectively.
+  A special value that can be used as transition results to cause a
+  study to transition to the next step, whatever step that may be. 
+
+  The predicate @racket[next?] returns @racket[#t] if @racket[_v] is
+  identical to @racket[next], @racket[#f] otherwise.
+
+}
+
+@deftogether[(
+  @defthing[#:kind "canary" done done?]
+  @defproc[(done? [v any/c]) boolean?]
+)]{  
+  A special value that can be used as transition results to cause a
+  transition to the end of the study. 
+
+  The predicate @racket[done?] returns @racket[#t] if @racket[_v] is
+  identical to @racket[done], @racket[#f] otherwise.
+
 }
 
 @;------------------------------------------------

--- a/congame-doc/congame-reference.scrbl
+++ b/congame-doc/congame-reference.scrbl
@@ -477,7 +477,7 @@ is used as the button’s label.
                         (code:line (lambda () transition-expr ...+))
                         (code:line (lambda name:id () transition-expr ...+)))
 
-          (transition-expr (code:line (done))
+          (transition-expr (code:line done)
                            (code:line (fail expr))
                            (code:line (goto id:id))
                            (code:line expr))]

--- a/congame-doc/congame-reference.scrbl
+++ b/congame-doc/congame-reference.scrbl
@@ -466,19 +466,19 @@ is used as the button’s label.
 
 @defmodule[congame/components/transition-graph]
 
-@defform[#:literals (unquote lambda --> goto done fail)
+@defform[#:literals (unquote lambda --> goto quote)
          (transition-graph transition-clause ...+)
          #:grammar
-         [(transition-clause (code:line [id transition-entry ...+ maybe-lambda]))
+         [(transition-clause (code:line [id transition-entry ...+ maybe-expr]))
 
           (transition-entry (code:line --> id))
 
-          (maybe-lambda (code:line)
-                        (code:line (lambda () transition-expr ...+))
-                        (code:line (lambda name:id () transition-expr ...+)))
+          (maybe-expr (code:line)
+                      (code:line ,(lambda () transition-expr ...+))
+                      (code:line ,(lambda name:id () transition-expr ...+)))
 
-          (transition-expr (code:line done)
-                           (code:line (fail expr))
+          (transition-expr (code:line '(done))
+                           (code:line '(fail _))
                            (code:line (goto id:id))
                            (code:line expr))]
          ]{
@@ -492,20 +492,20 @@ is used as the button’s label.
     #:transitions
     (transition-graph
       [a --> b --> ,(lambda ()
-                      (if success-step-b?
-                        (goto bad-ending)
-                        (goto good-ending)))]
-      [fail-ending --> fail-ending]
+                      (if (not success-step-b?)
+                          (goto bad-ending)
+                          (goto good-ending)))]
+      [fail-ending --> ,(lambda () '(fail 0))]
       [good-ending --> good-ending])
     (list
       (make-step 'a a)
       (make-step 'b b)
-      (make-step 'c c)))
+      (make-step 'good-ending good)
+      (make-step 'fail-ending failed)))
   ]
 }
 
 @deftogether[(@defidform[-->]
-              @defform[(fail expr)]
               @defform[(goto step-id)])]{
 
 Forms used in @racket[transition-graph]s to define transitions between study steps. Use of these

--- a/congame-doc/conscript-cookbook.scrbl
+++ b/congame-doc/conscript-cookbook.scrbl
@@ -20,7 +20,43 @@ including the links in the code samples themselves.
 
 @section{Basic Study Recipe}
 
-@tktk{Example of complete, basic study}
+@codeblock|{
+#lang conscript
+
+(provide
+ conscript-example)
+
+(defstep (info)
+  @html{@h1{Hello!}
+        Welcome to the study.
+        @button{Continue}})
+
+(defstep (consent)
+  @html{@h1{Consent}
+        Do you consent to join the study?
+        @button{Give Consent}})
+
+(defstep (final)
+  @html{@h1{Done}
+        You're done.
+
+        @a[#:href (~current-view-uri)
+           #:up-layer "new"
+           #:up-target ".container"]{Overlay}})
+
+(defview (done-overlay _req)
+  @md{# Info
+
+      Blah blah blah.})
+
+(defstudy conscript-example
+  [info --> {consent1 consent}
+        --> {consent2 consent}
+        --> {final (make-step
+                   #:view-handler done-overlay
+                   'final final)}]
+  [final --> final])
+}|
 
 @;===============================================
 

--- a/congame-doc/conscript-reference.scrbl
+++ b/congame-doc/conscript-reference.scrbl
@@ -109,6 +109,7 @@ particular identifiers provided by @racket[_child-study-expr] upon completion. W
                         (code:line --> ,(lambda () transition-expr)))
           (transition-expr (code:line done)
                            (code:line (goto step))
+                           (code:line '(fail _))
                            (code:line 'step-id)
 @;{Returning 'step-id from unquoted lambda also seems to work, but this appears redunant to goto}
                            (code:line expr))
@@ -121,18 +122,15 @@ The use of @racket[#:requires] and @racket[#:provides] arguments is deprecated a
 compatibility. Use @racket[defvar*] and @racket[defvar*/instance] to share study variables between
 parent/child studies.
 
-@margin-note{The transitions follow the same grammar as @racket[transition-graph], @mark{except that
-you cannot use @racket[fail] expressions.}} 
-
-An unquoted lambda at the end of a @racket[transition-clause] can include arbitrary code
-(@racket[expr]) but must terminate in one of the other possible @racket[transition-expr]s:
+An unquoted lambda at the end of a @racket[transition-clause] can include arbitrary @racket[expr],
+but this but must evaluate to one of the other possible @racket[transition-expr]s:
 
 @racketblock[
 (defstudy college-try
   [attempt --> ,(lambda () (if success
                                (goto good-ending)
                                (goto bad-ending)))]
-  [bad-ending --> bad-ending]
+  [bad-ending --> ,(lambda () '(fail 0))]
   [good-ending --> good-ending])
 ]
 

--- a/congame-doc/conscript-reference.scrbl
+++ b/congame-doc/conscript-reference.scrbl
@@ -102,18 +102,21 @@ particular identifiers provided by @racket[_child-study-expr] upon completion. W
           (maybe-provides (code:line)
                           (code:line #:provides (value-id-sym ...)))
           (transition-clause [step --> transition ... maybe-lambda])
-          (transition [--> step])
+          (transition (code:line --> step)
+                      (code:line --> {step-id step}))
           (maybe-lambda (code:line)
                         (code:line --> ,(lambda () expr)))
           ]]{
 
-Defines a study in terms of steps joined by transitions. Each @racket[id] should be the identifier
-of a step defined with @racket[defstep] or @racket[defstep/study].
+Defines a study in terms of steps joined by transitions. Each @racket[step] should be a step defined
+with @racket[defstep] or @racket[defstep/study].
 
 The use of @racket[#:requires] and @racket[#:provides] arguments is deprecated and included for
 compatibility. Use @racket[defvar*] and @racket[defvar*/instance] to share study variables between
 parent/child studies.
 
+@;{Not sure if this paragraph is really needed, but want to flag the issues it raises for review at
+some point.}
 The transitions follow the same grammar as @racket[transition-graph], @mark{except that you cannot
 use @racket[goto] or @racket[fail] expressions, and uses of @racket[next] and @racket[done] must be
 returned as the result of the body of a @racket[maybe-lambda] expression.}
@@ -132,6 +135,17 @@ Example:
 (defstudy mystudy
   [intro --> question --> final --> ,(lambda () done)])
 
+]}
+
+You can reuse the same step function as separate steps with the @racket[--> {_step-id _step}] form of
+@racket[_transition]:
+
+@racketblock[
+(defstudy repeating-step-study
+  [intro --> {message1 message}
+         --> {message2 message}
+         --> final]
+  [final --> final])
 ]}
 
 @defproc[(put/identity [key symbol?] [value any/c]) void?]{

--- a/congame-doc/conscript-reference.scrbl
+++ b/congame-doc/conscript-reference.scrbl
@@ -227,7 +227,7 @@ server when the view is accessed.
          #:contracts ([req request?])]{
 
 Defines a @tech{view handler}. When the @tech{view} is accessed, Congame will call the view handler,
-passing the HTTP @racket[request] as the sole argument.
+passing the HTTP @racket[request] as the @racket[_req] argument.
 
 As with @racket[defstep], the @racket[_body] of a @racket[defview] expression should evaluate to a
 study @tech{page}, usually using @racket[md] or @racket[html]. The @racket[defview] form takes care
@@ -247,7 +247,8 @@ Example:
 
 @defproc[(~current-view-uri) string?]{
 
-Returns the URI of the current view handler page.
+Returns the URI of the view handler page associated with the current step. Intended for use inside
+@racket[defstep].
 
 }
 

--- a/congame-doc/install.scrbl
+++ b/congame-doc/install.scrbl
@@ -2,7 +2,7 @@
 
 @(require "doc-util.rkt")
 
-@title[#:tag "install-congame" #:style 'quiet]{Installing Congame and Conscript}
+@title[#:tag "install-congame" #:style 'quiet]{Installing, Running, and Updating}
 
 Below are step-by-step instructions for installing Congame and Conscript on your personal computer.
 

--- a/congame-example-study/conscript.rkt
+++ b/congame-example-study/conscript.rkt
@@ -13,7 +13,7 @@
         Do you consent to join the study?
         @button{Give Consent}})
 
-(defstep (done)
+(defstep (final)
   @html{@h1{Done}
         You're done.
 
@@ -29,7 +29,7 @@
 (defstudy conscript-example
   [info --> {consent1 consent}
         --> {consent2 consent}
-        --> {done (make-step
+        --> {final (make-step
                    #:view-handler done-overlay
-                   'done done)}]
-  [done --> done])
+                   'final final)}]
+  [final --> final])


### PR DESCRIPTION
Here are some further documentation updates. I'd appreciate a review of the updates to the grammars in docs for `defstudy` and `transition-graph`, as well as the `@mark`ed text in the `defstudy` section.

Will merge early next week if no objection. 